### PR TITLE
Bugfix and usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ RAID system a little easier.
 
 I'm hoping by putting this out there to encourage further development and extensions to try and bring `MegaCLI` under control.
 
+You can specify the MegaCLI path and enclosure by setting the following environment variables:
+
+| EnvVar Name | Default     | Description |
+| ----------- | ----------- | ----------- |
+| MEGACLI     | `/opt/MegaRAID/MegaCli/MegaCli64` if detected, else `/usr/sbin/megacli` | Full path to MegaCLI binary |
+| ENCLOSURE   | Detected by `lsi.sh` | Enclosure number to scan |
+
 # Environment
 
 I'm working under an Ubuntu/Debian environment, but I think the only

--- a/lsi.sh
+++ b/lsi.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# https://github.com/berkeleybop/lsi.sh
 #
 # Calomel.org 
 #     https://calomel.org/megacli_lsi_commands.html
@@ -8,11 +9,17 @@
 # description: MegaCLI script to configure and monitor LSI raid cards.
 
 # Full path to the MegaRaid CLI binary
-MegaCli="/usr/sbin/megacli"
+# Check the common install paths, preferng /opt/MegaRAID
+DETECT_MEGACLI="/opt/MegaRAID/MegaCli/MegaCli64"
+if !([ -f "${DETECT_MEGACLI}" ] && [ -r "${DETECT_MEGACLI}" ] && [ -x "${DETECT_MEGACLI}" ]) ; then
+    DETECT_MEGACLI="/usr/sbin/megacli"
+fi
+MegaCli="${MEGACLI:-$DETECT_MEGACLI}"
 
 # The identifying number of the enclosure. Default for our systems is "8". Use
 # "sudo megacli -PDlist -a0 | grep "Enclosure Device" | uniq | awk '{print $NF}'" to see what your number is and set this variable.
-ENCLOSURE=`$MegaCli -PDlist -a0 | grep "Enclosure Device" | uniq | awk '{print $NF}'`
+DETECT_ENCLOSURE=`$MegaCli -PDlist -a0 | grep "Enclosure Device" | uniq | awk '{print $NF}'`
+ENCLOSURE="${ENCLOSURE:-$DETECT_ENCLOSURE}"
 
 if [ $# -eq 0 ]
    then
@@ -20,6 +27,7 @@ if [ $# -eq 0 ]
     echo "            OBPG  .:.  lsi.sh $arg1 $arg2"
     echo "-----------------------------------------------------"
     echo "VARIABLES:"
+    echo "megacli       = $MegaCli"
     echo "enclosure     = $ENCLOSURE"
     echo "COMMANDS:"
     echo "status        = Status of Virtual drives (volumes)"

--- a/lsi.sh
+++ b/lsi.sh
@@ -12,7 +12,7 @@ MegaCli="/usr/sbin/megacli"
 
 # The identifying number of the enclosure. Default for our systems is "8". Use
 # "sudo megacli -PDlist -a0 | grep "Enclosure Device" | uniq | awk '{print $NF}'" to see what your number is and set this variable.
-ENCLOSURE=`megacli -PDlist -a0 | grep "Enclosure Device" | uniq | awk '{print $NF}'`
+ENCLOSURE=`$MegaCli -PDlist -a0 | grep "Enclosure Device" | uniq | awk '{print $NF}'`
 
 if [ $# -eq 0 ]
    then


### PR DESCRIPTION
 * Fix `ENCLOSURE` auto-detection, to use the `$MegaCLI` env var
 * Added auto-dectection of the Broadcom-packaged `MegaCli` paths.
 * Added ability to specify `MEGACLI` and `ENCLOSURE`  through env var exports
 * Add some project attribution to the README, along with docs for the new features